### PR TITLE
Adds an .env file to define the API URL. #14

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+BASE_URL="https://mmapi.precisiontox.org/api"
+//BASE_URL="http://localhost:5000/api"

--- a/src/lib/RESTClient.js
+++ b/src/lib/RESTClient.js
@@ -1,7 +1,6 @@
 import axios from 'axios'
 
-const BASE_URL = "https://mmapi.precisiontox.org/api"
-//const BASE_URL = "http://localhost:5000/api"
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5000/api'
 const HEADERS = { "Content-Type": "application/json", "Accept": "application/json" }
 
 


### PR DESCRIPTION
It turns out that newer versions of Nuxt already support .env files. 
If an .env file isn't detected it will default to the development URL. Copy .env.example to .env to use production. 