### PR TITLE
Fix for inability to login on the production site.

### DIFF
--- a/src/lib/RESTClient.js
+++ b/src/lib/RESTClient.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const BASE_URL = process.env.BASE_URL || 'http://localhost:5000/api'
+const BASE_URL = process.env.BASE_URL || 'https://mmapi.precisiontox.org/api'
 const HEADERS = { "Content-Type": "application/json", "Accept": "application/json" }
 
 


### PR DESCRIPTION
It appears that environmental variables aren't respected by Netlify for client-side applications.
Therefore, I can only think of making the production URL the default for this application and overriding it locally for development with an .env file.
This PR does that and so should fix logins when merged. 